### PR TITLE
Rearrange namespaces

### DIFF
--- a/StreamRegex.Benchmarks/AsyncVsSyncBenchmarks.cs
+++ b/StreamRegex.Benchmarks/AsyncVsSyncBenchmarks.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 using BenchmarkDotNet.Attributes;
-using StreamRegex.Extensions;
+using StreamRegex.Extensions.RegexExtensions;
 using StreamRegex.Lib.DFA;
 using StreamRegex.Lib.NFA;
 

--- a/StreamRegex.Benchmarks/BufferSizeBenchmarks.cs
+++ b/StreamRegex.Benchmarks/BufferSizeBenchmarks.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 using BenchmarkDotNet.Attributes;
-using StreamRegex.Extensions;
+using StreamRegex.Extensions.RegexExtensions;
+using StreamRegex.Extensions.StringMethods;
 using StreamRegex.Lib.DFA;
 using StreamRegex.Lib.NFA;
 

--- a/StreamRegex.Benchmarks/LargeFileBenchmarks.cs
+++ b/StreamRegex.Benchmarks/LargeFileBenchmarks.cs
@@ -1,7 +1,8 @@
 ﻿using System.Text;
 using System.Text.RegularExpressions;
 using BenchmarkDotNet.Attributes;
-using StreamRegex.Extensions;
+using StreamRegex.Extensions.RegexExtensions;
+using StreamRegex.Extensions.StringMethods;
 using StreamRegex.Lib.DFA;
 using StreamRegex.Lib.NFA;
 

--- a/StreamRegex.Benchmarks/PerformanceVsStandard.cs
+++ b/StreamRegex.Benchmarks/PerformanceVsStandard.cs
@@ -1,7 +1,7 @@
 ﻿using System.Text.RegularExpressions;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Jobs;
-using StreamRegex.Extensions;
+using StreamRegex.Extensions.RegexExtensions;
 
 namespace StreamRegex.Benchmarks;
 [MemoryDiagnoser]

--- a/StreamRegex.Extensions/Core/SlidingBufferExtensions.cs
+++ b/StreamRegex.Extensions/Core/SlidingBufferExtensions.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 
-namespace StreamRegex.Extensions;
+namespace StreamRegex.Extensions.Core;
 
 /// <summary>
 /// Synchronous methods to perform arbitrary string check operations on <see cref="Stream"/> and <see cref="StreamReader"/>.
@@ -25,7 +25,7 @@ public static class SlidingBufferExtensions
     {
         return new StreamReader(streamToMatch).IsMatch(isMatchDelegate, options);
     }
-    
+
     /// <summary>
     /// Check if a <see cref="StreamReader"/> matches the provided <paramref name="isMatchDelegate"/>
     /// </summary>
@@ -34,7 +34,7 @@ public static class SlidingBufferExtensions
     /// <param name="options">The <see cref="SlidingBufferOptions"/> to use</param>
     /// <returns>True if the <paramref name="streamReaderToMatch"/> matches the <paramref name="isMatchDelegate"/></returns>
     public static bool IsMatch(this StreamReader streamReaderToMatch, IsMatchDelegate isMatchDelegate, SlidingBufferOptions? options = null)
-    {        
+    {
         var opts = options ?? new();
         var bufferSize = opts.BufferSize < opts.OverlapSize * 2 ? opts.OverlapSize * 2 : opts.BufferSize;
         // This is our string building buffer.
@@ -68,7 +68,7 @@ public static class SlidingBufferExtensions
 
         return false;
     }
-    
+
     /// <summary>
     /// Delegate for GetFirstMatch methods.
     /// </summary>
@@ -85,7 +85,7 @@ public static class SlidingBufferExtensions
     {
         return new StreamReader(streamToMatch).GetFirstMatch(getFirstMatchDelegate, options);
     }
-    
+
     /// <summary>
     /// Get the first match for a <see cref="StreamReader"/> from an Function.
     /// </summary>
@@ -94,7 +94,7 @@ public static class SlidingBufferExtensions
     /// <param name="options">The <see cref="SlidingBufferOptions"/> to use</param>
     /// <returns>A <see cref="SlidingBufferMatch"/> object representing the match state of the first match.</returns>
     public static SlidingBufferValueMatch GetFirstMatch(this StreamReader streamReaderToMatch, GetFirstMatchDelegate getFirstMatchDelegate, SlidingBufferOptions? options = null)
-    {        
+    {
         var opts = options ?? new();
         var bufferSize = opts.BufferSize < opts.OverlapSize * 2 ? opts.OverlapSize * 2 : opts.BufferSize;
         // This is our string building buffer.
@@ -131,13 +131,13 @@ public static class SlidingBufferExtensions
 
         return new SlidingBufferValueMatch();
     }
-    
+
     /// <summary>
     /// Delegate for GetMatchCollection methods.
     /// </summary>
     public delegate SlidingBufferValueMatchCollection<SlidingBufferValueMatch> GetMatchCollectionDelegate(ReadOnlySpan<char> chunk);
 
-        /// <summary>
+    /// <summary>
     /// Get the all matches for a <see cref="Stream"/> from an Function.
     /// </summary>
     /// <param name="streamToMatch">The <see cref="Stream"/> to check for matches</param>
@@ -157,7 +157,7 @@ public static class SlidingBufferExtensions
     /// <param name="options">The <see cref="SlidingBufferOptions"/> to use</param>
     /// <returns>A <see cref="SlidingBufferMatchCollection{SlidingBufferMatch}"/> object with all the matches for the <paramref name="streamReaderToMatch"/>.</returns>
     public static SlidingBufferValueMatchCollection<SlidingBufferValueMatch> GetMatchCollection(this StreamReader streamReaderToMatch, GetMatchCollectionDelegate getMatchCollectionDelegate, SlidingBufferOptions? options = null)
-    {        
+    {
         SlidingBufferValueMatchCollection<SlidingBufferValueMatch> collection = new();
 
         var opts = options ?? new();

--- a/StreamRegex.Extensions/Core/SlidingBufferExtensionsAsync.cs
+++ b/StreamRegex.Extensions/Core/SlidingBufferExtensionsAsync.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace StreamRegex.Extensions;
+namespace StreamRegex.Extensions.Core;
 
 /// <summary>
 /// Asyncronous Extension methods for matching <see cref="Stream"/> and <see cref="StreamReader"/>.
@@ -30,7 +30,7 @@ public static class SlidingBufferExtensionsAsync
     /// <param name="options">The <see cref="SlidingBufferOptions"/> to use</param>
     /// <returns>True if the <paramref name="streamReaderToMatch"/> matches the <paramref name="action"/></returns>
     public static async Task<bool> IsMatchAsync(this StreamReader streamReaderToMatch, Func<string, bool> action, SlidingBufferOptions? options = null)
-    {        
+    {
         var opts = options ?? new();
         var bufferSize = opts.BufferSize < opts.OverlapSize * 2 ? opts.OverlapSize * 2 : opts.BufferSize;
         // This is our string building buffer.
@@ -96,7 +96,7 @@ public static class SlidingBufferExtensionsAsync
     /// <param name="options">The <see cref="SlidingBufferOptions"/> to use</param>
     /// <returns>A <see cref="SlidingBufferMatchCollection{SlidingBufferMatch}"/> object with all the matches for the <paramref name="streamReaderToMatch"/>.</returns>
     public static async Task<SlidingBufferMatchCollection<SlidingBufferMatch>> GetMatchCollectionAsync(this StreamReader streamReaderToMatch, Func<string, IEnumerable<SlidingBufferMatch>> action, SlidingBufferOptions? options = null)
-    {        
+    {
         SlidingBufferMatchCollection<SlidingBufferMatch> collection = new();
 
         var opts = options ?? new();
@@ -135,7 +135,7 @@ public static class SlidingBufferExtensionsAsync
 
         return collection;
     }
-    
+
     /// <summary>
     /// Check if a StreamReader matches a Function
     /// </summary>
@@ -144,7 +144,7 @@ public static class SlidingBufferExtensionsAsync
     /// <param name="options"></param>
     /// <returns></returns>
     public static async Task<SlidingBufferMatch> GetFirstMatchAsync(this StreamReader toMatch, Func<string, SlidingBufferMatch> action, SlidingBufferOptions? options = null)
-    {        
+    {
         var opts = options ?? new();
         var bufferSize = opts.BufferSize < opts.OverlapSize * 2 ? opts.OverlapSize * 2 : opts.BufferSize;
         // This is our string building buffer.

--- a/StreamRegex.Extensions/RegexExtensions/RegexCache.cs
+++ b/StreamRegex.Extensions/RegexExtensions/RegexCache.cs
@@ -3,7 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
-namespace StreamRegex.Extensions;
+namespace StreamRegex.Extensions.RegexExtensions;
 
 /// <summary>
 /// A bag of <see cref="Regex"/> to use with the extension methods.
@@ -21,7 +21,7 @@ public class RegexCache : IEnumerable<Regex>
             _collection.Add(regex);
         }
     }
-    
+
     private readonly ConcurrentBag<Regex> _collection = new();
 
     /// <summary>
@@ -32,7 +32,7 @@ public class RegexCache : IEnumerable<Regex>
     {
         return _collection.GetEnumerator();
     }
-    
+
     IEnumerator IEnumerable.GetEnumerator()
     {
         return GetEnumerator();

--- a/StreamRegex.Extensions/RegexExtensions/RegexMethods.cs
+++ b/StreamRegex.Extensions/RegexExtensions/RegexMethods.cs
@@ -2,8 +2,9 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using System.Linq;
+using StreamRegex.Extensions.Core;
 
-namespace StreamRegex.Extensions;
+namespace StreamRegex.Extensions.RegexExtensions;
 
 /// <summary>
 /// This class has the methods for the <see cref="StreamRegexExtensions"/> to use with the <see cref="SlidingBufferExtensions"/>
@@ -71,7 +72,7 @@ internal class RegexMethods
 
         return false;
     }
-    
+
     internal SlidingBufferValueMatchCollection<SlidingBufferValueMatch> RegexGetMatchCollectionDelegate(ReadOnlySpan<char> chunk)
     {
 #if NET7_0_OR_GREATER
@@ -112,7 +113,7 @@ internal class RegexMethods
                 return true;
             }
         }
-        
+
         return false;
     }
 

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensions.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensions.cs
@@ -2,8 +2,10 @@
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
+using StreamRegex.Extensions.Core;
+using StreamRegex.Extensions.RegexExtensions;
 
-namespace StreamRegex.Extensions;
+namespace StreamRegex.Extensions.RegexExtensions;
 
 /// <summary>
 /// Extends the <see cref="Regex"/> class with functionality to check against <see cref="StreamReader"/>.
@@ -45,7 +47,7 @@ public static class StreamRegexExtensions
     /// <returns>True if there is at least one match.</returns>
     public static bool IsMatch(this Regex engine, StreamReader toMatch, StreamRegexOptions? options = null)
     {
-        return new[] {engine}.IsMatch(toMatch, options);
+        return new[] { engine }.IsMatch(toMatch, options);
     }
 
     /// <summary>
@@ -57,7 +59,7 @@ public static class StreamRegexExtensions
     /// <returns>True if there is at least one match.</returns>
     public static bool IsMatch(this Regex engine, Stream toMatch, StreamRegexOptions? options = null)
     {
-        return new[] {engine}.IsMatch(toMatch, options);
+        return new[] { engine }.IsMatch(toMatch, options);
     }
 
     /// <summary>
@@ -82,7 +84,7 @@ public static class StreamRegexExtensions
     /// <returns>A <see cref="StreamRegexMatch"/> object representing the first, or lack of, Match.</returns>
     public static StreamRegexValueMatch GetFirstMatch(this Regex engine, StreamReader toMatch, StreamRegexOptions? options = null)
     {
-        return new[]{engine}.GetFirstMatch(toMatch, options);
+        return new[] { engine }.GetFirstMatch(toMatch, options);
     }
 
     /// <summary>
@@ -112,7 +114,7 @@ public static class StreamRegexExtensions
     /// <returns>A <see cref="SlidingBufferMatchCollection{StreamRegexMatch}"/> object representing all matches. This collection will be empty if there are no matches.</returns>
     public static SlidingBufferValueMatchCollection<SlidingBufferValueMatch> GetMatchCollection(this Regex engine, Stream toMatch, StreamRegexOptions? options = null)
     {
-        return new[]{engine}.GetMatchCollection(new StreamReader(toMatch), options);
+        return new[] { engine }.GetMatchCollection(new StreamReader(toMatch), options);
     }
 
     /// <summary>
@@ -124,7 +126,7 @@ public static class StreamRegexExtensions
     /// <returns>A <see cref="SlidingBufferMatchCollection{StreamRegexMatch}"/> object representing all matches. This collection will be empty if there are no matches.</returns>
     public static SlidingBufferValueMatchCollection<SlidingBufferValueMatch> GetMatchCollection(this Regex engine, StreamReader toMatch, StreamRegexOptions? options = null)
     {
-        return new[]{engine}.GetMatchCollection(toMatch, options);
+        return new[] { engine }.GetMatchCollection(toMatch, options);
     }
 
     /// <summary>

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensionsAsync.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensionsAsync.cs
@@ -2,8 +2,10 @@
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using StreamRegex.Extensions.Core;
+using StreamRegex.Extensions.RegexExtensions;
 
-namespace StreamRegex.Extensions;
+namespace StreamRegex.Extensions.RegexExtensions;
 
 /// <summary>
 /// Extends the <see cref="Regex"/> class with functionality to <see cref="Regex"/> asynchronously against <see cref="Stream"/> and <see cref="StreamReader"/>.
@@ -37,7 +39,7 @@ public static class StreamRegexExtensionsAsync
         var reader = new StreamReader(streamToMatch);
         return await engines.IsMatchAsync(reader, options);
     }
-    
+
     /// <summary>
     /// Find if a <see cref="Stream"/> matches a <see cref="Regex"/>.
     /// </summary>
@@ -50,7 +52,7 @@ public static class StreamRegexExtensionsAsync
         var reader = new StreamReader(streamToMatch);
         return await engine.IsMatchAsync(reader, options);
     }
-    
+
     /// <summary>
     /// Find if a <see cref="StreamReader"/> matches a regular expression.
     /// </summary>
@@ -104,7 +106,7 @@ public static class StreamRegexExtensionsAsync
     /// <returns>A <see cref="StreamRegexMatch"/> object representing the first match, or lack of match.</returns>
     public static async Task<StreamRegexMatch> GetFirstMatchAsync(this Regex engine, StreamReader streamReaderToMatch, StreamRegexOptions? options = null)
     {
-        return await new[]{engine}.GetFirstMatchAsync(streamReaderToMatch, options);
+        return await new[] { engine }.GetFirstMatchAsync(streamReaderToMatch, options);
     }
 
     /// <summary>
@@ -121,7 +123,7 @@ public static class StreamRegexExtensionsAsync
         RegexMethods methods = new RegexMethods(engines);
         return (StreamRegexMatch)await streamReaderToMatch.GetFirstMatchAsync(methods.RegexGetFirstMatchFunction);
     }
-    
+
     /// <summary>
     /// Find all matches for a given <see cref="Regex"/>
     /// </summary>
@@ -131,9 +133,9 @@ public static class StreamRegexExtensionsAsync
     /// <returns>A <see cref="SlidingBufferMatchCollection{StreamRegexMatch}"/> object representing all matches. This object will be empty if there are no matches.</returns>
     public static async Task<SlidingBufferMatchCollection<SlidingBufferMatch>> GetMatchCollectionAsync(this Regex engine, Stream toMatch, StreamRegexOptions? options = null)
     {
-        return await new[]{engine}.GetMatchCollectionAsync(new StreamReader(toMatch), options);
+        return await new[] { engine }.GetMatchCollectionAsync(new StreamReader(toMatch), options);
     }
-    
+
     /// <summary>
     /// Find all matches for a given <see cref="Regex"/>
     /// </summary>
@@ -143,9 +145,9 @@ public static class StreamRegexExtensionsAsync
     /// <returns>A <see cref="SlidingBufferMatchCollection{StreamRegexMatch}"/> object representing all matches. This object will be empty if there are no matches.</returns>
     public static async Task<SlidingBufferMatchCollection<SlidingBufferMatch>> GetMatchCollectionAsync(this Regex engine, StreamReader toMatch, StreamRegexOptions? options = null)
     {
-        return await new[]{engine}.GetMatchCollectionAsync(toMatch, options);
+        return await new[] { engine }.GetMatchCollectionAsync(toMatch, options);
     }
-    
+
     /// <summary>
     /// Find all matches for the engines in the set of regexes, for example a <see cref="RegexCache"/>
     /// </summary>

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexMatch.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexMatch.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 
-namespace StreamRegex.Extensions;
+namespace StreamRegex.Extensions.RegexExtensions;
 
 /// <summary>
 /// A sliding buffer match from a <see cref="Regex"/>.

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexOptions.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexOptions.cs
@@ -1,4 +1,4 @@
-﻿namespace StreamRegex.Extensions;
+﻿namespace StreamRegex.Extensions.RegexExtensions;
 
 /// <summary>
 /// Currently this doesn't take any options other than those in <see cref="SlidingBufferOptions"/>.

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexValueMatch.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexValueMatch.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 
-namespace StreamRegex.Extensions;
+namespace StreamRegex.Extensions.RegexExtensions;
 
 /// <summary>
 /// A sliding buffer value match from a <see cref="Regex"/>.

--- a/StreamRegex.Extensions/SlidingBufferMatchCollection.cs
+++ b/StreamRegex.Extensions/SlidingBufferMatchCollection.cs
@@ -1,6 +1,17 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Concurrent;
+
+/* Unmerged change from project 'StreamRegex.Extensions (netstandard2.1)'
+Before:
+using System.Collections.Generic;
+After:
+using System.Collections.Generic;
+using StreamRegex;
+using StreamRegex.Extensions;
+using StreamRegex.Extensions;
+using StreamRegex.Extensions.Core;
+*/
 using System.Collections.Generic;
 
 namespace StreamRegex.Extensions;
@@ -28,7 +39,7 @@ public class SlidingBufferMatchCollection<T> : IEnumerable<T>, ICollection, IRea
     /// </summary>
     public object SyncRoot => throw new NotSupportedException();
 
-    internal SlidingBufferMatchCollection(){}
+    internal SlidingBufferMatchCollection() { }
 
     /// <summary>
     /// Add a <see cref="SlidingBufferMatch"/> to the collection.  If the same match has already been added no-op.
@@ -41,7 +52,7 @@ public class SlidingBufferMatchCollection<T> : IEnumerable<T>, ICollection, IRea
             _collection.Enqueue(match);
         }
     }
-    
+
     /// <summary>
     /// Add the matches in the provided <paramref name="matchCollection"/> to this collection. The added matches will be deduplicated.
     /// </summary>

--- a/StreamRegex.Extensions/SlidingBufferValueMatchCollection.cs
+++ b/StreamRegex.Extensions/SlidingBufferValueMatchCollection.cs
@@ -1,6 +1,17 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Concurrent;
+
+/* Unmerged change from project 'StreamRegex.Extensions (netstandard2.1)'
+Before:
+using System.Collections.Generic;
+After:
+using System.Collections.Generic;
+using StreamRegex;
+using StreamRegex.Extensions;
+using StreamRegex.Extensions;
+using StreamRegex.Extensions.Core;
+*/
 using System.Collections.Generic;
 
 namespace StreamRegex.Extensions;
@@ -28,7 +39,7 @@ public class SlidingBufferValueMatchCollection<T> : IEnumerable<T>, ICollection,
     /// </summary>
     public object SyncRoot => throw new NotSupportedException();
 
-    internal SlidingBufferValueMatchCollection(){}
+    internal SlidingBufferValueMatchCollection() { }
 
     /// <summary>
     /// Add a <see cref="SlidingBufferMatch"/> to the collection.  If the same match has already been added no-op.
@@ -41,7 +52,7 @@ public class SlidingBufferValueMatchCollection<T> : IEnumerable<T>, ICollection,
             _collection.Enqueue(match);
         }
     }
-    
+
     /// <summary>
     /// Add the matches in the provided <paramref name="matchCollection"/> to this collection. The added matches will be deduplicated.
     /// </summary>

--- a/StreamRegex.Extensions/StreamRegex.Extensions.csproj
+++ b/StreamRegex.Extensions/StreamRegex.Extensions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Nullable>enable</Nullable>

--- a/StreamRegex.Tests/ExtensionTests.cs
+++ b/StreamRegex.Tests/ExtensionTests.cs
@@ -6,7 +6,8 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StreamRegex.Extensions;
-
+using StreamRegex.Extensions.RegexExtensions;
+using StreamRegex.Extensions.StringMethods;
 
 namespace StreamRegex.Tests;
 

--- a/StreamRegex.Tests/ExtensionTestsAsync.cs
+++ b/StreamRegex.Tests/ExtensionTestsAsync.cs
@@ -7,7 +7,8 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StreamRegex.Extensions;
-
+using StreamRegex.Extensions.RegexExtensions;
+using StreamRegex.Extensions.StringMethods;
 
 namespace StreamRegex.Tests;
 


### PR DESCRIPTION
Split functions into sub namespaces so you can pull in just the regex etc. 