### PR TITLE
Simplify collection api

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ public SlidingBufferMatchCollection<SlidingBufferMatch> YourMethod(ReadOnlySpan<
     {
         matchCollection.Add(match);
     }
+    return matchCollection;
 }
 
 var collection = reader.GetMatchCollection(YourMethod);

--- a/README.md
+++ b/README.md
@@ -194,7 +194,10 @@ YourEngine engine = new MatchingEngine();
 public SlidingBufferMatchCollection<SlidingBufferMatch> YourMethod(ReadOnlySpan<char> arg)
 {
     SlidingBufferMatchCollection<SlidingBufferMatch> matchCollection = new SlidingBufferMatchCollection<SlidingBufferMatch>();
-    matchCollection.AddMatches(engine.MakeMatches(arg));
+    foreach(var match in engine.MakeMatches(arg))
+    {
+        matchCollection.Add(match);
+    }
 }
 
 var collection = reader.GetMatchCollection(YourMethod);

--- a/README.md
+++ b/README.md
@@ -155,14 +155,11 @@ using StreamRegex.Extensions.Core;
 // Create your stream reader
 StreamReader reader = new StreamReader(stream);
 
-string target = "Something";
-
 // Return the index of the target string relative to the chunk. 
 // It will be adjusted to the correct relative position for the Stream automatically.
 SlidingBufferMatch YourMethod(ReadOnlySpan<char> chunk)
 {
-    var idx = contentChunk.IndexOf(target, comparison);
-    if (idx != -1)
+    if (SomeCheckOf(chunk))
     {
         return new SlidingBufferMatch(true, idx, target.Length);
     }
@@ -190,18 +187,29 @@ using StreamRegex.Extensions.Core;
 // Create your stream reader
 StreamReader reader = new StreamReader(stream);
 // Your arbitrary engine that can generate multiple matches
-YourEngine engine = new MatchingEngine();
-public SlidingBufferMatchCollection<SlidingBufferMatch> YourMethod(ReadOnlySpan<char> arg)
+YourEngineHolder matchingEngine = new YourEngineHolder();
+
+public class YourEngineHolder
 {
-    SlidingBufferMatchCollection<SlidingBufferMatch> matchCollection = new SlidingBufferMatchCollection<SlidingBufferMatch>();
-    foreach(var match in engine.MakeMatches(arg))
+    private YourMatchingEngine _internalEngine;
+    
+    public YourEngineHolder()
     {
-        matchCollection.Add(match);
+        _internalEngine = new YourMatchingEngine();
     }
-    return matchCollection;
+    
+    public SlidingBufferMatchCollection<SlidingBufferMatch> YourMethod(ReadOnlySpan<char> arg)
+    {
+        SlidingBufferMatchCollection<SlidingBufferMatch> matchCollection = new SlidingBufferMatchCollection<SlidingBufferMatch>();
+        foreach(var match in _internalEngine.MakeMatches(arg))
+        {
+            matchCollection.Add(match);
+        }
+        return matchCollection;
+    }
 }
 
-var collection = reader.GetMatchCollection(YourMethod);
+var collection = reader.GetMatchCollection(matchingEngine.YourMethod);
 ```
 
 ## How it works

--- a/StreamRegex.Extensions/Core/SlidingBufferExtensions.cs
+++ b/StreamRegex.Extensions/Core/SlidingBufferExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 
 namespace StreamRegex.Extensions.Core;

--- a/StreamRegex.Extensions/Core/SlidingBufferExtensions.cs
+++ b/StreamRegex.Extensions/Core/SlidingBufferExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 
 namespace StreamRegex.Extensions.Core;
 
@@ -24,7 +25,7 @@ public static class SlidingBufferExtensions
     /// <returns>True if the <paramref name="streamToMatch"/> matches the <paramref name="isMatchDelegate"/></returns>
     public static bool IsMatch(this Stream streamToMatch, IsMatchDelegate isMatchDelegate, SlidingBufferOptions? options = null)
     {
-        return new StreamReader(streamToMatch).IsMatch(isMatchDelegate, options);
+        return new StreamReader(streamToMatch, Encoding.Default, true, 4096, true).IsMatch(isMatchDelegate, options);
     }
 
     /// <summary>
@@ -86,7 +87,7 @@ public static class SlidingBufferExtensions
     /// <returns>A <see cref="SlidingBufferMatch"/> object representing the match state of the first match.</returns>
     public static SlidingBufferMatch GetFirstMatch(this Stream streamToMatch, GetFirstMatchDelegate getFirstMatchDelegate, SlidingBufferOptions? options = null)
     {
-        return new StreamReader(streamToMatch).GetFirstMatch(getFirstMatchDelegate, options);
+        return new StreamReader(streamToMatch, Encoding.Default, true, 4096, true).GetFirstMatch(getFirstMatchDelegate, options);
     }
 
     /// <summary>
@@ -151,7 +152,7 @@ public static class SlidingBufferExtensions
     /// <returns>A <see cref="SlidingBufferMatchCollection{SlidingBufferMatch}"/> object with all the matches for the <paramref name="streamToMatch"/>.</returns>
     public static SlidingBufferMatchCollection<SlidingBufferMatch> GetMatchCollection(this Stream streamToMatch, GetMatchCollectionDelegate getMatchCollectionDelegate, SlidingBufferOptions? options = null)
     {
-        return new StreamReader(streamToMatch).GetMatchCollection(getMatchCollectionDelegate, options);
+        return new StreamReader(streamToMatch, Encoding.Default, true, 4096, true).GetMatchCollection(getMatchCollectionDelegate, options);
     }
 
     /// <summary>

--- a/StreamRegex.Extensions/Core/SlidingBufferExtensions.cs
+++ b/StreamRegex.Extensions/Core/SlidingBufferExtensions.cs
@@ -184,7 +184,7 @@ public static class SlidingBufferExtensions
             {
                 // Adjust the match position
                 match.Index += offset > 0 ? offset - opts.OverlapSize : 0;
-                collection.AddMatch(match);
+                collection.Add(match);
             }
             offset += numChars;
             // This is an indication there is no more to read.

--- a/StreamRegex.Extensions/Core/SlidingBufferExtensionsAsync.cs
+++ b/StreamRegex.Extensions/Core/SlidingBufferExtensionsAsync.cs
@@ -117,7 +117,7 @@ public static class SlidingBufferExtensionsAsync
             {
                 // Adjust the match position
                 match.Index += offset > 0 ? offset - opts.OverlapSize : 0;
-                collection.AddMatch(match);
+                collection.Add(match);
             }
             offset += numChars;
             // This is an indication there is no more to read.

--- a/StreamRegex.Extensions/Core/SlidingBufferExtensionsAsync.cs
+++ b/StreamRegex.Extensions/Core/SlidingBufferExtensionsAsync.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace StreamRegex.Extensions.Core;
@@ -19,7 +20,7 @@ public static class SlidingBufferExtensionsAsync
     /// <returns>True if the <paramref name="tomatch"/> matches the <paramref name="action"/>></returns>
     public static async Task<bool> IsMatchAsync(this Stream tomatch, Func<string, bool> action, SlidingBufferOptions? options = null)
     {
-        return await new StreamReader(tomatch).IsMatchAsync(action, options);
+        return await new StreamReader(tomatch, Encoding.Default, true, 4096, true).IsMatchAsync(action, options);
     }
 
     /// <summary>
@@ -73,7 +74,7 @@ public static class SlidingBufferExtensionsAsync
     /// <returns>A <see cref="SlidingBufferMatch"/> object representing the match state of the first match.</returns>
     public static async Task<SlidingBufferMatch> GetFirstMatchAsync(this Stream streamToMatch, Func<string, SlidingBufferMatch> action, SlidingBufferOptions? options = null)
     {
-        return await new StreamReader(streamToMatch).GetFirstMatchAsync(action, options);
+        return await new StreamReader(streamToMatch, Encoding.Default, true, 4096, true).GetFirstMatchAsync(action, options);
     }
 
     /// <summary>
@@ -85,7 +86,7 @@ public static class SlidingBufferExtensionsAsync
     /// <returns>A <see cref="SlidingBufferMatchCollection{SlidingBufferMatch}"/> object with all the matches for the <paramref name="streamToMatch"/>.</returns>
     public static async Task<SlidingBufferMatchCollection<SlidingBufferMatch>> GetMatchCollectionAsync(this Stream streamToMatch, Func<string, IEnumerable<SlidingBufferMatch>> action, SlidingBufferOptions? options = null)
     {
-        return await new StreamReader(streamToMatch).GetMatchCollectionAsync(action, options);
+        return await new StreamReader(streamToMatch, Encoding.Default, true, 4096, true).GetMatchCollectionAsync(action, options);
     }
 
     /// <summary>

--- a/StreamRegex.Extensions/RegexExtensions/RegexMethods.cs
+++ b/StreamRegex.Extensions/RegexExtensions/RegexMethods.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using System.Linq;
 using StreamRegex.Extensions.Core;
 
 namespace StreamRegex.Extensions.RegexExtensions;

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensions.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensions.cs
@@ -113,7 +113,7 @@ public static class StreamRegexExtensions
     /// <returns>A <see cref="SlidingBufferMatchCollection{StreamRegexMatch}"/> object representing all matches. This collection will be empty if there are no matches.</returns>
     public static SlidingBufferMatchCollection<StreamRegexMatch> GetMatchCollection(this Regex engine, Stream toMatch, StreamRegexOptions? options = null)
     {
-        return new[] { engine }.GetMatchCollection(new StreamReader(toMatch), options);
+        return new[] { engine }.GetMatchCollection(new StreamReader(toMatch, Encoding.Default, true, 4096, true), options);
     }
 
     /// <summary>

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensions.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensions.cs
@@ -145,7 +145,7 @@ public static class StreamRegexExtensions
         {
             if (match is StreamRegexMatch srvm)
             {
-                regexMatches.AddMatch(srvm);
+                regexMatches.Add(srvm);
             }
         }
         return regexMatches;

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensions.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensions.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
 using StreamRegex.Extensions.Core;
-using StreamRegex.Extensions.RegexExtensions;
 
 namespace StreamRegex.Extensions.RegexExtensions;
 

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensionsAsync.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensionsAsync.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using StreamRegex.Extensions.Core;
@@ -35,7 +36,7 @@ public static class StreamRegexExtensionsAsync
     /// <returns>True if there is at least one match.</returns>
     public static async Task<bool> IsMatchAsync(this IEnumerable<Regex> engines, Stream streamToMatch, StreamRegexOptions? options = null)
     {
-        var reader = new StreamReader(streamToMatch);
+        var reader = new StreamReader(streamToMatch, Encoding.Default, true, 4096, true);
         return await engines.IsMatchAsync(reader, options);
     }
 
@@ -48,7 +49,7 @@ public static class StreamRegexExtensionsAsync
     /// <returns>True if there is at least one match.</returns>
     public static async Task<bool> IsMatchAsync(this Regex engine, Stream streamToMatch, StreamRegexOptions? options = null)
     {
-        var reader = new StreamReader(streamToMatch);
+        var reader = new StreamReader(streamToMatch, Encoding.Default, true, 4096, true);
         return await engine.IsMatchAsync(reader, options);
     }
 
@@ -78,7 +79,7 @@ public static class StreamRegexExtensionsAsync
     /// <returns>A <see cref="StreamRegexMatch"/> object representing the first match, or lack of match.</returns>
     public static async Task<StreamRegexMatch> GetFirstMatchAsync(this Regex engine, Stream streamToMatch, StreamRegexOptions? options = null)
     {
-        using var reader = new StreamReader(streamToMatch);
+        using var reader = new StreamReader(streamToMatch, Encoding.Default, true, 4096, true);
         return await engine.GetFirstMatchAsync(reader, options);
     }
 
@@ -92,7 +93,7 @@ public static class StreamRegexExtensionsAsync
     /// <returns>A <see cref="StreamRegexMatch"/> object representing the first match, or lack of match.</returns>
     public static async Task<StreamRegexMatch> GetFirstMatchAsync(this IEnumerable<Regex> engines, Stream streamToMatch, StreamRegexOptions? options = null)
     {
-        using var reader = new StreamReader(streamToMatch);
+        using var reader = new StreamReader(streamToMatch, Encoding.Default, true, 4096, true);
         return await engines.GetFirstMatchAsync(reader, options);
     }
 
@@ -132,7 +133,7 @@ public static class StreamRegexExtensionsAsync
     /// <returns>A <see cref="SlidingBufferMatchCollection{StreamRegexMatch}"/> object representing all matches. This object will be empty if there are no matches.</returns>
     public static async Task<SlidingBufferMatchCollection<SlidingBufferMatch>> GetMatchCollectionAsync(this Regex engine, Stream toMatch, StreamRegexOptions? options = null)
     {
-        return await new[] { engine }.GetMatchCollectionAsync(new StreamReader(toMatch), options);
+        return await new[] { engine }.GetMatchCollectionAsync(new StreamReader(toMatch, Encoding.Default, true, 4096, true), options);
     }
 
     /// <summary>

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensionsAsync.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensionsAsync.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using StreamRegex.Extensions.Core;
-using StreamRegex.Extensions.RegexExtensions;
 
 namespace StreamRegex.Extensions.RegexExtensions;
 

--- a/StreamRegex.Extensions/SlidingBufferMatchCollection.cs
+++ b/StreamRegex.Extensions/SlidingBufferMatchCollection.cs
@@ -40,19 +40,7 @@ public class SlidingBufferMatchCollection<T> : IEnumerable<T>, ICollection, IRea
     public object SyncRoot => throw new NotSupportedException();
 
     internal SlidingBufferMatchCollection() { }
-
-    /// <summary>
-    /// Add a <see cref="SlidingBufferMatch"/> to the collection.  If the same match has already been added no-op.
-    /// </summary>
-    /// <param name="match">The match to add.</param>
-    public void AddMatch(T match)
-    {
-        if (_deduper.TryAdd(match, true))
-        {
-            _collection.Enqueue(match);
-        }
-    }
-
+    
     /// <summary>
     /// Add the matches in the provided <paramref name="matchCollection"/> to this collection. The added matches will be deduplicated.
     /// </summary>
@@ -61,7 +49,7 @@ public class SlidingBufferMatchCollection<T> : IEnumerable<T>, ICollection, IRea
     {
         foreach (var match in matchCollection)
         {
-            AddMatch(match);
+            Add(match);
         }
     }
 
@@ -94,7 +82,10 @@ public class SlidingBufferMatchCollection<T> : IEnumerable<T>, ICollection, IRea
         return GetEnumerator();
     }
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Add a <see cref="SlidingBufferMatch"/> to the collection.  If the same match has already been added no-op.
+    /// </summary>
+    /// <param name="item">The match to add.</param>
     public void Add(T item)
     {
         if (_deduper.TryAdd(item, true))

--- a/StreamRegex.Extensions/StringMethods/StringMatcher.cs
+++ b/StreamRegex.Extensions/StringMethods/StringMatcher.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace StreamRegex.Extensions.StringMethods
 {

--- a/StreamRegex.Extensions/StringMethods/StringMethodExtensionsAsync.cs
+++ b/StreamRegex.Extensions/StringMethods/StringMethodExtensionsAsync.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using StreamRegex.Extensions.Core;
 
@@ -22,7 +23,7 @@ public static class StringMethodExtensionsAsync
     /// <returns>True if <paramref name="value"/> is contained in <paramref name="streamToCheck"/></returns>
     public static async Task<bool> ContainsAsync(this Stream streamToCheck, string value, StringComparison? comparisonType = null, SlidingBufferOptions? options = null)
     {
-        return await new StreamReader(streamToCheck).ContainsAsync(value, comparisonType, options);
+        return await new StreamReader(streamToCheck, Encoding.Default, true, 4096, true).ContainsAsync(value, comparisonType, options);
     }
 
     /// <summary>
@@ -53,7 +54,7 @@ public static class StringMethodExtensionsAsync
 
     public static async Task<long> IndexOfAsync(this Stream streamToCheck, string value, StringComparison? comparisonType = null, SlidingBufferOptions? options = null)
     {
-        return await new StreamReader(streamToCheck).IndexOfAsync(value, comparisonType, options);
+        return await new StreamReader(streamToCheck, Encoding.Default, true, 4096, true).IndexOfAsync(value, comparisonType, options);
     }
 
     /// <summary>


### PR DESCRIPTION
Simplify the APIs on the SlidingBufferMatchCollection.
Simplify backing collection on SlidingBufferMatchCollection.
Remove unused usings.
Fix closing Streams with implicit StreamReader.
Update Readme.