### PR TITLE
Improve async performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,12 @@ We find that the majority of the operation time is spent on reading full Stream 
 
 ### Async vs Sync
 
-Because Span is not supported in async contexts async is significantly slower.
+Because Span is not supported in async contexts async is a bit slower.
 
-|              Method | TestFileName |     Mean |   Error |  StdDev | Ratio | RatioSD |      Gen 0 |     Gen 1 | Allocated |
-|-------------------- |------------- |---------:|--------:|--------:|------:|--------:|-----------:|----------:|----------:|
-|      RegexExtension |    175MB.txt | 193.3 ms | 2.93 ms | 2.74 ms |  1.00 |    0.00 | 23000.0000 |         - |    370 MB |
-| RegexExtensionAsync |    175MB.txt | 406.8 ms | 7.71 ms | 8.25 ms |  2.10 |    0.06 | 43000.0000 | 1000.0000 |    384 MB |
+|              Method | paddingSegmentLength | numberPaddingSegmentsBefore | numberPaddingSegmentsAfter |     Mean |    Error |   StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
+|-------------------- |--------------------- |---------------------------- |--------------------------- |---------:|---------:|---------:|------:|--------:|----------:|------------:|
+|      RegexExtension |                 1000 |                      200000 |                     200000 | 36.73 ms | 0.679 ms | 1.372 ms |  1.00 |    0.00 |   3.37MB |        1.00 |
+| RegexExtensionAsync |                 1000 |                      200000 |                     200000 | 47.92 ms | 0.671 ms | 0.628 ms |  1.28 |    0.05 |   3.37MB |        1.00 |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ We find that the majority of the operation time is spent on reading full Stream 
 
 ### Async vs Sync
 
-Because Span is not supported in async contexts async is a bit slower.
+Async reading from Streams is also fast and low allocation.
 
 |              Method | paddingSegmentLength | numberPaddingSegmentsBefore | numberPaddingSegmentsAfter |     Mean |    Error |   StdDev | Ratio | RatioSD | Allocated | Alloc Ratio |
 |-------------------- |--------------------- |---------------------------- |--------------------------- |---------:|---------:|---------:|------:|--------:|----------:|------------:|

--- a/StreamRegex.Benchmarks/AsyncVsSyncBenchmarks.cs
+++ b/StreamRegex.Benchmarks/AsyncVsSyncBenchmarks.cs
@@ -10,39 +10,75 @@ namespace StreamRegex.Benchmarks;
 [ExcludeFromCodeCoverage]
 public class AsyncVsSyncBenchmarks
 {
-    private readonly Regex _compiled;
-    private const string Pattern = "racecar";
-    private Stream _stream = new MemoryStream();
     public AsyncVsSyncBenchmarks()
     {
         _compiled = new Regex(Pattern, RegexOptions.Compiled);
     }
 
+    private readonly Regex _compiled;
+    private const string Pattern = "racecar";
+    private Dictionary<(int, int, int), Stream> _streams = new();
+
+    // Does not contain e so cannot match racecar
+    string chars = "abcdfghijklmnopqrstuvwxyz123456789";
+    Random random = new Random();
+
     [IterationSetup]
     public void IterationSetup()
     {
-        _stream = File.OpenRead(TestFileName);
+        if (!_streams.ContainsKey((numberPaddingSegmentsBefore, numberPaddingSegmentsAfter, paddingSegmentLength)))
+        {
+            var _stream = new MemoryStream();
+            var streamWriter = new StreamWriter(_stream, leaveOpen: true);
+            for (int i = 0; i < numberPaddingSegmentsBefore; i++)
+            {
+                streamWriter.Write(getRandomString(paddingSegmentLength));
+            }
+
+            streamWriter.Write(Pattern);
+
+            for (int i = 0; i < numberPaddingSegmentsAfter; i++)
+            {
+                streamWriter.Write(getRandomString(paddingSegmentLength));
+            }
+            streamWriter.Close();
+            _streams[(numberPaddingSegmentsBefore, numberPaddingSegmentsAfter, paddingSegmentLength)] = _stream;
+        }
+        _streams[(numberPaddingSegmentsBefore, numberPaddingSegmentsAfter, paddingSegmentLength)].Position = 0;
     }
 
-    [IterationCleanup]
-    public void IterationCleanup()
+    private string getRandomString(int numCharacters)
     {
-        _stream.Dispose();
+        return new string(Enumerable.Repeat(0, numCharacters).Select(_ => chars[random.Next(chars.Length)]).ToArray());
     }
     
-    //[Params("TargetStart.txt","TargetMiddle.txt","TargetEnd.txt")]
-    [Params("175MB.txt")]
-    public string TestFileName { get; set; }
+    const int zeroPadding = 0;
+
+    // 100 MB
+    const int midPadding = 1000 * 100;
+
+    // 200 MB
+    const int longPadding = 1000 * 200;
+
+
+    [Params(1000)]
+    public int paddingSegmentLength { get; set; }
+    // [Params(zeroPadding, midPadding, longPadding)]
+    [Params(longPadding)]
+    public int numberPaddingSegmentsBefore { get; set; }
+    // [Params(zeroPadding, midPadding, longPadding)]
+    [Params(longPadding)]
+    public int numberPaddingSegmentsAfter { get; set; }
 
     [BenchmarkCategory("AsyncVsSync")]
     [Benchmark(Baseline = true)]
     public void RegexExtension()
     {
-        var content = new StreamReader(_stream);
-        var match = _compiled.GetFirstMatch(content);
-        if (match.Success)
+        _streams[(numberPaddingSegmentsBefore, numberPaddingSegmentsAfter, paddingSegmentLength)].Position = 0;
+        var content = new StreamReader(_streams[(numberPaddingSegmentsBefore, numberPaddingSegmentsAfter, paddingSegmentLength)], leaveOpen: true);
+        if (!_compiled.IsMatch(content))
         {
-            //
+            throw new Exception($"The regex didn't match.");
         }
     }
     
@@ -50,11 +86,12 @@ public class AsyncVsSyncBenchmarks
     [Benchmark]
     public async Task RegexExtensionAsync()
     {
-        var content = new StreamReader(_stream);
-        var match = await _compiled.GetFirstMatchAsync(content);
-        if (match.Success)
+        _streams[(numberPaddingSegmentsBefore, numberPaddingSegmentsAfter, paddingSegmentLength)].Position = 0;
+        var content = new StreamReader(_streams[(numberPaddingSegmentsBefore, numberPaddingSegmentsAfter, paddingSegmentLength)], leaveOpen: true);
+        var match = await _compiled.IsMatchAsync(content);
+        if (!match)
         {
-            //
+            throw new Exception($"The regex didn't match.");
         }
     }
 }

--- a/StreamRegex.Benchmarks/PerformanceVsStandard.cs
+++ b/StreamRegex.Benchmarks/PerformanceVsStandard.cs
@@ -12,10 +12,8 @@ public class PerformanceVsStandard
 {
     private readonly Regex _compiled = new Regex(Pattern, RegexOptions.Compiled);
     private const string Pattern = "racecar";
-    //private Stream _stream = new MemoryStream();
     private Dictionary<(int, int, int), Stream> _streams = new();
 
-    private Dictionary<(int, int, int), string> _strings = new();
     // Does not contain e so cannot match racecar
     string chars = "abcdfghijklmnopqrstuvwxyz123456789";
     Random random = new Random();

--- a/StreamRegex.Benchmarks/Program.cs
+++ b/StreamRegex.Benchmarks/Program.cs
@@ -10,7 +10,7 @@ public class Program
 {
     public static void Main(string[] args)
     {
-        var summary = BenchmarkRunner.Run<PerformanceVsStandard>();
+        var summary = BenchmarkRunner.Run<AsyncVsSyncBenchmarks>();
     }    
 }
 // NFATest();

--- a/StreamRegex.Extensions/Core/SlidingBufferExtensionsAsync.cs
+++ b/StreamRegex.Extensions/Core/SlidingBufferExtensionsAsync.cs
@@ -18,7 +18,7 @@ public static class SlidingBufferExtensionsAsync
     /// <param name="action">The Function to run</param>
     /// <param name="options">The <see cref="SlidingBufferOptions"/> to use</param>
     /// <returns>True if the <paramref name="tomatch"/> matches the <paramref name="action"/>></returns>
-    public static async Task<bool> IsMatchAsync(this Stream tomatch, Func<string, bool> action, SlidingBufferOptions? options = null)
+    public static async Task<bool> IsMatchAsync(this Stream tomatch, SlidingBufferExtensions.IsMatchDelegate action, SlidingBufferOptions? options = null)
     {
         return await new StreamReader(tomatch, Encoding.Default, true, 4096, true).IsMatchAsync(action, options);
     }
@@ -30,7 +30,7 @@ public static class SlidingBufferExtensionsAsync
     /// <param name="action">The Function to run</param>
     /// <param name="options">The <see cref="SlidingBufferOptions"/> to use</param>
     /// <returns>True if the <paramref name="streamReaderToMatch"/> matches the <paramref name="action"/></returns>
-    public static async Task<bool> IsMatchAsync(this StreamReader streamReaderToMatch, Func<string, bool> action, SlidingBufferOptions? options = null)
+    public static async Task<bool> IsMatchAsync(this StreamReader streamReaderToMatch, SlidingBufferExtensions.IsMatchDelegate action, SlidingBufferOptions? options = null)
     {
         var opts = options ?? new();
         var bufferSize = opts.BufferSize < opts.OverlapSize * 2 ? opts.OverlapSize * 2 : opts.BufferSize;
@@ -44,7 +44,7 @@ public static class SlidingBufferExtensionsAsync
             // The number of characters to read out of the builder
             // Characters after this are not valid for this read
             var numValidCharacters = offset > 0 ? numChars + opts.OverlapSize : numChars;
-            if (action.Invoke(buffer[..numValidCharacters].ToString()))
+            if (action.Invoke(buffer.Span, opts.DelegateOptions))
             {
                 return true;
             }
@@ -72,7 +72,7 @@ public static class SlidingBufferExtensionsAsync
     /// <param name="action">The Function to run</param>
     /// <param name="options">The <see cref="SlidingBufferOptions"/> to use</param>
     /// <returns>A <see cref="SlidingBufferMatch"/> object representing the match state of the first match.</returns>
-    public static async Task<SlidingBufferMatch> GetFirstMatchAsync(this Stream streamToMatch, Func<string, SlidingBufferMatch> action, SlidingBufferOptions? options = null)
+    public static async Task<SlidingBufferMatch> GetFirstMatchAsync(this Stream streamToMatch, SlidingBufferExtensions.GetFirstMatchDelegate action, SlidingBufferOptions? options = null)
     {
         return await new StreamReader(streamToMatch, Encoding.Default, true, 4096, true).GetFirstMatchAsync(action, options);
     }
@@ -84,7 +84,7 @@ public static class SlidingBufferExtensionsAsync
     /// <param name="action">The Function to run</param>
     /// <param name="options">The <see cref="SlidingBufferOptions"/> to use</param>
     /// <returns>A <see cref="SlidingBufferMatchCollection{SlidingBufferMatch}"/> object with all the matches for the <paramref name="streamToMatch"/>.</returns>
-    public static async Task<SlidingBufferMatchCollection<SlidingBufferMatch>> GetMatchCollectionAsync(this Stream streamToMatch, Func<string, IEnumerable<SlidingBufferMatch>> action, SlidingBufferOptions? options = null)
+    public static async Task<SlidingBufferMatchCollection<SlidingBufferMatch>> GetMatchCollectionAsync(this Stream streamToMatch, SlidingBufferExtensions.GetMatchCollectionDelegate action, SlidingBufferOptions? options = null)
     {
         return await new StreamReader(streamToMatch, Encoding.Default, true, 4096, true).GetMatchCollectionAsync(action, options);
     }
@@ -96,7 +96,7 @@ public static class SlidingBufferExtensionsAsync
     /// <param name="action">The Function to run</param>
     /// <param name="options">The <see cref="SlidingBufferOptions"/> to use</param>
     /// <returns>A <see cref="SlidingBufferMatchCollection{SlidingBufferMatch}"/> object with all the matches for the <paramref name="streamReaderToMatch"/>.</returns>
-    public static async Task<SlidingBufferMatchCollection<SlidingBufferMatch>> GetMatchCollectionAsync(this StreamReader streamReaderToMatch, Func<string, IEnumerable<SlidingBufferMatch>> action, SlidingBufferOptions? options = null)
+    public static async Task<SlidingBufferMatchCollection<SlidingBufferMatch>> GetMatchCollectionAsync(this StreamReader streamReaderToMatch, SlidingBufferExtensions.GetMatchCollectionDelegate action, SlidingBufferOptions? options = null)
     {
         SlidingBufferMatchCollection<SlidingBufferMatch> collection = new();
 
@@ -113,7 +113,7 @@ public static class SlidingBufferExtensionsAsync
             // The number of characters to read out of the builder
             // Characters after this are not valid for this read
             var numValidCharacters = offset > 0 ? numChars + opts.OverlapSize : numChars;
-            var matches = action.Invoke(buffer[..numValidCharacters].ToString());
+            var matches = action.Invoke(buffer.Span, opts.DelegateOptions);
             foreach (SlidingBufferMatch match in matches)
             {
                 // Adjust the match position
@@ -144,7 +144,7 @@ public static class SlidingBufferExtensionsAsync
     /// <param name="action"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    public static async Task<SlidingBufferMatch> GetFirstMatchAsync(this StreamReader toMatch, Func<string, SlidingBufferMatch> action, SlidingBufferOptions? options = null)
+    public static async Task<SlidingBufferMatch> GetFirstMatchAsync(this StreamReader toMatch, SlidingBufferExtensions.GetFirstMatchDelegate action, SlidingBufferOptions? options = null)
     {
         var opts = options ?? new();
         var bufferSize = opts.BufferSize < opts.OverlapSize * 2 ? opts.OverlapSize * 2 : opts.BufferSize;
@@ -159,7 +159,7 @@ public static class SlidingBufferExtensionsAsync
             // The number of characters to read out of the builder
             // Characters after this are not valid for this read
             var numValidCharacters = offset > 0 ? numChars + opts.OverlapSize : numChars;
-            var match = action.Invoke(buffer[..numValidCharacters].ToString());
+            var match = action.Invoke(buffer[..numValidCharacters].Span, opts.DelegateOptions);
             if (match.Success)
             {
                 match.Index += offset > 0 ? offset - opts.OverlapSize : 0;

--- a/StreamRegex.Extensions/RegexExtensions/RegexMethods.cs
+++ b/StreamRegex.Extensions/RegexExtensions/RegexMethods.cs
@@ -17,61 +17,6 @@ internal class RegexMethods
         _engines = engines is RegexCache cache ? cache : new RegexCache(engines);
     }
 
-    /// <summary>
-    /// Used for Async methods which cannot use the Span based delegates
-    /// </summary>
-    /// <param name="arg"></param>
-    /// <returns></returns>
-    internal IEnumerable<StreamRegexMatch> RegexGetMatchCollectionFunction(string arg)
-    {
-        foreach (var engine in _engines)
-        {
-            MatchCollection matches = engine.Matches(arg);
-            foreach (Match match in matches)
-            {
-                yield return new StreamRegexMatch(engine, true, match.Index, match.Length, match.Value);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Used for Async methods which cannot use the Span based delegates
-    /// </summary>
-    /// <param name="arg"></param>
-    /// <returns></returns>
-    internal StreamRegexMatch RegexGetFirstMatchFunction(string arg)
-    {
-        foreach (var engine in _engines)
-        {
-            var match = engine.Match(arg);
-            if (match.Success)
-            {
-                return new StreamRegexMatch(engine, true, match.Index, match.Length, match.Value);
-            }
-        }
-
-        return new StreamRegexMatch(null);
-    }
-
-    /// <summary>
-    /// Used for Async methods which cannot use the Span based delegates
-    /// </summary>
-    /// <param name="arg"></param>
-    /// <returns></returns>
-    internal bool RegexIsMatchFunction(string arg)
-    {
-        foreach (var engine in _engines)
-        {
-            var match = engine.Match(arg);
-            if (match.Success)
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     internal SlidingBufferMatchCollection<SlidingBufferMatch> RegexGetMatchCollectionDelegate(ReadOnlySpan<char> chunk, DelegateOptions delegateOptions)
     {
 #if NET7_0_OR_GREATER

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensionsAsync.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensionsAsync.cs
@@ -23,7 +23,7 @@ public static class StreamRegexExtensionsAsync
     public static async Task<bool> IsMatchAsync(this IEnumerable<Regex> engines, StreamReader streamReaderToMatch, StreamRegexOptions? options = null)
     {
         var methods = new RegexMethods(engines);
-        return await streamReaderToMatch.IsMatchAsync(methods.RegexIsMatchFunction, options);
+        return await streamReaderToMatch.IsMatchAsync(methods.RegexIsMatchDelegate, options);
     }
 
     /// <summary>
@@ -121,7 +121,7 @@ public static class StreamRegexExtensionsAsync
     public static async Task<StreamRegexMatch> GetFirstMatchAsync(this IEnumerable<Regex> engines, StreamReader streamReaderToMatch, StreamRegexOptions? options = null)
     {
         RegexMethods methods = new RegexMethods(engines);
-        return (StreamRegexMatch)await streamReaderToMatch.GetFirstMatchAsync(methods.RegexGetFirstMatchFunction);
+        return (StreamRegexMatch)await streamReaderToMatch.GetFirstMatchAsync(methods.RegexGetFirstMatchDelegate);
     }
 
     /// <summary>
@@ -158,6 +158,6 @@ public static class StreamRegexExtensionsAsync
     public static async Task<SlidingBufferMatchCollection<SlidingBufferMatch>> GetMatchCollectionAsync(this IEnumerable<Regex> engines, StreamReader toMatch, StreamRegexOptions? options = null)
     {
         RegexMethods methods = new RegexMethods(engines);
-        return await toMatch.GetMatchCollectionAsync(methods.RegexGetMatchCollectionFunction, options);
+        return await toMatch.GetMatchCollectionAsync(methods.RegexGetMatchCollectionDelegate, options);
     }
 }

--- a/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensionsAsync.cs
+++ b/StreamRegex.Extensions/RegexExtensions/StreamRegexExtensionsAsync.cs
@@ -121,7 +121,7 @@ public static class StreamRegexExtensionsAsync
     public static async Task<StreamRegexMatch> GetFirstMatchAsync(this IEnumerable<Regex> engines, StreamReader streamReaderToMatch, StreamRegexOptions? options = null)
     {
         RegexMethods methods = new RegexMethods(engines);
-        return (StreamRegexMatch)await streamReaderToMatch.GetFirstMatchAsync(methods.RegexGetFirstMatchDelegate);
+        return (StreamRegexMatch)await streamReaderToMatch.GetFirstMatchAsync(methods.RegexGetFirstMatchDelegate, options);
     }
 
     /// <summary>

--- a/StreamRegex.Tests/ExtensionTestsAsync.cs
+++ b/StreamRegex.Tests/ExtensionTestsAsync.cs
@@ -35,7 +35,8 @@ public class AsyncExtensionTests
         var res = await compiled.GetFirstMatchAsync(StringToStream(ShortTestString), new StreamRegexOptions()
         {
             BufferSize = 4,
-            OverlapSize = 2
+            OverlapSize = 2,
+            DelegateOptions = new DelegateOptions(){ CaptureValues = true }
         });
         Assert.IsTrue(res.Success);
         Assert.AreEqual("45",res.Value);
@@ -51,7 +52,9 @@ public class AsyncExtensionTests
         var opts = new StreamRegexOptions()
         {
             BufferSize = 4,
-            OverlapSize = 2
+            OverlapSize = 2,
+            DelegateOptions = new DelegateOptions(){CaptureValues = true}
+
         };
         var collection = await compiled.GetMatchCollectionAsync(StringToStream("123456"), opts);
         Assert.AreEqual(1, collection.Count());

--- a/StreamRegex.Tests/ExtensionTestsAsync.cs
+++ b/StreamRegex.Tests/ExtensionTestsAsync.cs
@@ -132,9 +132,13 @@ public class AsyncExtensionTests
         var compiled = new Regex(ShortPattern, RegexOptions.Compiled);
         var prefix = string.Join(string.Empty,Enumerable.Repeat("z", 10000));
         var str = $"{prefix}racecar{prefix}";
-        var res = await compiled.GetFirstMatchAsync(StringToStream(str));
+        var res = await compiled.GetFirstMatchAsync(StringToStream(str), new StreamRegexOptions(){DelegateOptions = new DelegateOptions(){CaptureValues = true}});
         Assert.IsTrue(res.Success);
         Assert.AreEqual("racecar",res.Value);
+        res = await compiled.GetFirstMatchAsync(StringToStream(str));
+        Assert.IsTrue(res.Success);
+        Assert.IsNull(res.Value);
+
     }
 
     [TestMethod]
@@ -143,7 +147,7 @@ public class AsyncExtensionTests
         var compiled = new Regex(ShortPattern, RegexOptions.Compiled);
         var prefix = string.Join(string.Empty,Enumerable.Repeat("z", 10000));
         var str = $"{prefix}racecar{prefix}";
-        var res = await compiled.GetFirstMatchAsync(StringToStream(str));
+        var res = await compiled.GetFirstMatchAsync(StringToStream(str), new StreamRegexOptions(){DelegateOptions = new DelegateOptions(){CaptureValues = true}});
         var res2 = compiled.Match(str);
         Assert.IsTrue(res.Success);
         Assert.AreEqual("racecar",res.Value);

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1",
+  "version": "1.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Use the .Span attribute of the memory buffer and the span methods from the standard execution. Updates benchmarks with improved results.
Semver bump because of changes in Asynchronous APIs